### PR TITLE
Fix themes CTA link and title

### DIFF
--- a/components/home/mainSection/MainSection.tsx
+++ b/components/home/mainSection/MainSection.tsx
@@ -56,10 +56,10 @@ export default function MainSection({
         <section className="relative">
           {groups.length > 4 && (
             <Link
-              href="/groups"
+              href="/themes"
               className={`font-montserrat font-semibold flex items-center gap-1 uppercase hover:text-darkaccent ml-auto w-fit absolute right-0 top-[-30px]`}
             >
-              View all categories
+              View all themes
               <ArrowLongRightIcon width={16} />
             </Link>
           )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved navigation on the home page: when more than four groups are shown, the “View all” link now reads “View all themes” and directs to the themes page, replacing the previous “View all categories” link to the groups page. This makes it clearer where users will land and better aligns the label with the destination without changing the surrounding layout or conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->