### PR TITLE
Export data as CSV instead of JSON

### DIFF
--- a/components/responsiveGrid/TableActions.tsx
+++ b/components/responsiveGrid/TableActions.tsx
@@ -5,7 +5,9 @@ export default function TableActions() {
   const { dataUrl, data } = useResourceData();
   const handleDownload = () => {
     const csv = Papa.unparse(data);
-    const blob = new Blob([csv], { type: "text/csv" });
+    const blob = new Blob(["\uFEFF" + csv], {
+      type: "text/csv;charset=utf-8;",
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;


### PR DESCRIPTION
Related to #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancement**
  * Exported data now downloads as a CSV file (data.csv) with UTF-8 BOM for better compatibility with spreadsheet and analysis tools, replacing the previous JSON export.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->